### PR TITLE
Added initial Cargo config file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+
+name = "graphics"
+version = "0.0.0"
+authors = [
+    "bvssvni <bvssvni@gmail.com>",
+    "Coeuvre <coeuvre@gmail.com>",
+    "leonkunert <info@leonkunert.de>",
+    "gmorenz",
+    "Potpourri",
+    "TyOverby <ty@pre-alpha.com>"]
+
+[dependencies.gl-rs]
+
+git = "https://github.com/bjz/gl-rs.git"
+
+[dependencies.image]
+
+git = "https://github.com/PistonDevelopers/rust-image.git"
+
+[[lib]]
+
+name = "graphics"
+path = "./src/lib.rs"


### PR DESCRIPTION
DO NOT MERGE THIS UNTIL https://github.com/PistonDevelopers/rust-image/pull/39 LANDS.

Because rust-graphics depends on rust-image, Cargo support for rust-graphics depends on Cargo support for rust-image.  However, I've tested locally, so once support lands in rust-image, this should be able to merge without any issues.
