### PR TITLE
Use rustup to handle installation for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: c
+env:
+  - LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/
 install:
-  - curl -O http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
-  - tar xfz rust-nightly-x86_64-unknown-linux-gnu.tar.gz
-  - (cd rust-nightly-x86_64-unknown-linux-gnu/ && sudo ./install.sh)
-  - git clone --recursive https://github.com/rust-lang/cargo
-  - cd cargo
-  - make && sudo make install
-  - cd -
+  - curl www.rust-lang.org/rustup.sh | sudo bash
 script:
-  - rustc --version verbose 
-  - cargo build
+  - rustc --version
+  - cargo build -v
+os:
+  - linux


### PR DESCRIPTION
rustup now installs both the latest rust nightly and cargo,
so we no longer need to manually manage the installation process
for cargo or rust.
