### PR TITLE
Reexported `texture::ImageSize`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ path = "./src/lib.rs"
 
 git = "https://github.com/PistonDevelopers/vecmath"
 
+[dependencies.texture]
+
+git = "https://github.com/PistonDevelopers/texture"
+

--- a/src/image_size.rs
+++ b/src/image_size.rs
@@ -1,9 +1,0 @@
-
-/// Must be implemented by all images to be used with graphics back-end.
-///
-/// Rust-Graphics only needs to know the size.
-pub trait ImageSize {
-    /// Get the image size.
-    fn get_size(&self) -> (u32, u32);
-}
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@
 //! A library for 2D graphics that works with multiple back-ends.
 
 extern crate "vecmath" as vecmath_lib;
+extern crate texture;
+
+pub use texture::ImageSize;
 
 pub use add::{
     AddBevel,
@@ -25,7 +28,6 @@ pub use add::{
 };
 pub use back_end::BackEnd;
 pub use draw::Draw;
-pub use image_size::ImageSize;
 pub use relative::{
     RelativeColor,
     RelativeRectangle,
@@ -49,7 +51,6 @@ mod add;
 mod back_end;
 mod context;
 mod draw;
-mod image_size;
 mod relative;
 mod view;
 


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/graphics/issues/684
