### PR TITLE
Renamed `BackEnd` to `Graphics`

### DIFF
--- a/src/back_end.rs
+++ b/src/back_end.rs
@@ -1,7 +1,7 @@
 use ImageSize;
 
 /// Implemented by all graphics back-ends.
-pub trait BackEnd {
+pub trait Graphics {
     /// The texture type associated with the back-end.
     type Texture: ImageSize;
 
@@ -19,7 +19,7 @@ pub trait BackEnd {
     fn tri_list_uv<F>(
         &mut self, 
         color: &[f32; 4],
-        texture: &<Self as BackEnd>::Texture, 
+        texture: &<Self as Graphics>::Texture, 
         f: F
     ) where F: FnMut(&mut FnMut(&[f32], &[f32]));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,8 @@ extern crate interpolation;
 
 pub use texture::ImageSize;
 
-pub use back_end::BackEnd;
+pub use back_end::Graphics;
+pub use back_end::Graphics as BackEnd;
 pub use relative::{
     RelativeColor,
     RelativeRectangle,


### PR DESCRIPTION
* Added type alias to avoid breaking code

See https://github.com/PistonDevelopers/graphics/issues/842