### PR TITLE
Revert "Depend on crates.io packages"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,26 @@ homepage = "https://github.com/pistondevelopers/graphics"
 name = "graphics"
 path = "./src/lib.rs"
 
+[dependencies.vecmath]
+git = "https://github.com/PistonDevelopers/vecmath"
+#version = "0.0.5"
+
+[dependencies.draw_state]
+git = "https://github.com/gfx-rs/draw_state"
+#version = "0.0.5"
+
+[dependencies.piston-texture]
+git = "https://github.com/PistonDevelopers/texture"
+#version = "0.0.1"
+
+[dependencies.read_color]
+git = "https://github.com/PistonDevelopers/read_color"
+#version = "0.0.2"
+
+[dependencies.interpolation]
+git = "https://github.com/PistonDevelopers/interpolation"
+#version = "0.0.3"
+
 [dependencies]
 
 num = "0.1"
-vecmath = "0.0.6"
-draw_state = "0.0.7"
-piston-texture = "0.0.1"
-read_color = "0.0.2"
-interpolation = "0.0.4"


### PR DESCRIPTION
Reverts PistonDevelopers/graphics#903

I'm reverting this because we need the comments to know where the dependencies are on Github and what's on crates.io