### PR TITLE
Add a struct version of types::Rectangle

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub mod ellipse;
 pub mod rectangle;
 pub mod image;
 pub mod types;
+pub mod types_new;
 pub mod modular_index;
 pub mod text;
 pub mod triangulation;

--- a/src/types_new.rs
+++ b/src/types_new.rs
@@ -1,6 +1,6 @@
 //! Contains types used in this library
 use std::convert::From;
-use std::ops::{ Add, Mul };
+use std::ops::{ Add, Mul, Sub };
 
 pub use math::{ Matrix2d, Scalar, Vec2d };
 
@@ -39,27 +39,11 @@ impl Mul<Vec2d> for Dimensions {
     }
 }
 
-impl Mul<Dimensions> for Vec2d {
-    type Output = Dimensions;
-
-    fn mul(self, d: Dimensions) -> Dimensions {
-        Dimensions { width: d.width * self[0], height: d.height * self[1] }
-    }
-}
-
 impl Mul<Scalar> for Dimensions {
     type Output = Dimensions;
 
     fn mul(self, s: Scalar) -> Dimensions {
         Dimensions { width: self.width * s, height: self.height * s }
-    }
-}
-
-impl Mul<Dimensions> for Scalar {
-    type Output = Dimensions;
-
-    fn mul(self, d: Dimensions) -> Dimensions {
-        Dimensions { width: d.width * self, height: d.height * self }
     }
 }
 
@@ -70,22 +54,6 @@ pub struct Point {
     y: Scalar,
 }
 
-impl Add<Vec2d> for Point {
-    type Output = Point;
-
-    fn add(self, v: Vec2d) -> Point {
-        Point { x: self.x + v[0], y: self.y + v[1] }
-    }
-}
-
-impl Add<Point> for Vec2d {
-    type Output = Point;
-
-    fn add(self, p: Point) -> Point {
-        Point { x: p.x + self[0], y: p.y + self[1] }
-    }
-}
-
 impl Add<Scalar> for Point {
     type Output = Point;
 
@@ -94,17 +62,33 @@ impl Add<Scalar> for Point {
     }
 }
 
-impl Add<Point> for Scalar {
+impl Add<Vec2d> for Point {
     type Output = Point;
 
-    fn add(self, p: Point) -> Point {
-        Point { x: p.x + self, y: p.y + self }
+    fn add(self, v: Vec2d) -> Point {
+        Point { x: self.x + v[0], y: self.y + v[1] }
     }
 }
 
 impl From<Vec2d> for Point {
     fn from(v: Vec2d) -> Point {
         Point { x: v[0], y: v[1] }
+    }
+}
+
+impl Sub<Scalar> for Point {
+    type Output = Point;
+
+    fn sub(self, s: Scalar) -> Point {
+        Point { x: self.x - s, y: self.y - s }
+    }
+}
+
+impl Sub<Vec2d> for Point {
+    type Output = Point;
+
+    fn sub(self, v: Vec2d) -> Point {
+        Point { x: self.x - v[0], y: self.y - v[1] }
     }
 }
 
@@ -180,7 +164,7 @@ impl Rectangle {
                  x: self.pos.x - self.dim.width,
                  y: self.pos.y - self.dim.height,
             },
-            dim: 2.0 * self.dim,
+            dim: self.dim * 2.0,
         }
     }
 

--- a/src/types_new.rs
+++ b/src/types_new.rs
@@ -1,0 +1,268 @@
+//! Contains types used in this library
+use std::convert::From;
+use std::ops::{ Add, Mul };
+
+pub use math::{ Matrix2d, Scalar, Vec2d };
+
+/// A circle.
+#[derive(Clone, Copy, Debug)]
+pub struct Circle {
+    center: Point,
+    radius: Scalar,
+}
+
+/// The dimensions of a shape.
+#[derive(Clone, Copy, Debug)]
+pub struct Dimensions {
+    width: Scalar,
+    height: Scalar,
+}
+
+impl From<Vec2d> for Dimensions {
+    fn from(v: Vec2d) -> Dimensions {
+        Dimensions { width: v[0], height: v[1] }
+    }
+}
+
+impl Dimensions {
+    /// Convert dimenions to a vector.
+    pub fn to_vec(&self) -> Vec2d {
+        [self.width, self.height]
+    }
+}
+
+impl Mul<Vec2d> for Dimensions {
+    type Output = Dimensions;
+
+    fn mul(self, v: Vec2d) -> Dimensions {
+        Dimensions { width: self.width * v[0], height: self.height * v[1] }
+    }
+}
+
+impl Mul<Dimensions> for Vec2d {
+    type Output = Dimensions;
+
+    fn mul(self, d: Dimensions) -> Dimensions {
+        Dimensions { width: d.width * self[0], height: d.height * self[1] }
+    }
+}
+
+impl Mul<Scalar> for Dimensions {
+    type Output = Dimensions;
+
+    fn mul(self, s: Scalar) -> Dimensions {
+        Dimensions { width: self.width * s, height: self.height * s }
+    }
+}
+
+impl Mul<Dimensions> for Scalar {
+    type Output = Dimensions;
+
+    fn mul(self, d: Dimensions) -> Dimensions {
+        Dimensions { width: d.width * self, height: d.height * self }
+    }
+}
+
+/// A point in the Cartesian plane.
+#[derive(Clone, Copy, Debug)]
+pub struct Point {
+    x: Scalar,
+    y: Scalar,
+}
+
+impl Add<Vec2d> for Point {
+    type Output = Point;
+
+    fn add(self, v: Vec2d) -> Point {
+        Point { x: self.x + v[0], y: self.y + v[1] }
+    }
+}
+
+impl Add<Point> for Vec2d {
+    type Output = Point;
+
+    fn add(self, p: Point) -> Point {
+        Point { x: p.x + self[0], y: p.y + self[1] }
+    }
+}
+
+impl Add<Scalar> for Point {
+    type Output = Point;
+
+    fn add(self, s: Scalar) -> Point {
+        Point { x: self.x + s, y: self.y + s }
+    }
+}
+
+impl Add<Point> for Scalar {
+    type Output = Point;
+
+    fn add(self, p: Point) -> Point {
+        Point { x: p.x + self, y: p.y + self }
+    }
+}
+
+impl From<Vec2d> for Point {
+    fn from(v: Vec2d) -> Point {
+        Point { x: v[0], y: v[1] }
+    }
+}
+
+impl Point {
+    /// Convert the point to a vector.
+    pub fn to_vec(&self) -> Vec2d {
+        [self.x, self.y]
+    }
+}
+
+/// A rectangle whose top left corner is at (x, y).
+#[derive(Clone, Copy, Debug)]
+pub struct Rectangle {
+    pos: Point,
+    dim: Dimensions,
+}
+
+impl From<Circle> for Rectangle {
+    /// Convert from a circle to a rectangle.
+    fn from(c: Circle) -> Rectangle {
+        Rectangle {
+            pos: Point {
+                x: c.center.x - c.radius,
+                y: c.center.y - c.radius,
+            },
+            dim: Dimensions {
+                width: 2.0 * c.radius,
+                height: 2.0 * c.radius,
+            },
+        }
+    }
+}
+
+impl From<(Point, Dimensions)> for Rectangle {
+    /// Creates a rectangle from the position of its top left corner and its dimensions.
+    fn from(rectangle: (Point, Dimensions)) -> Rectangle {
+        let (pos, dim) = rectangle;
+        Rectangle { pos: pos, dim: dim }
+    }
+}
+
+impl From<[Scalar; 4]> for Rectangle {
+    /// Creates a rectangle from an array.
+    fn from(v: [Scalar; 4]) -> Rectangle {
+        Rectangle {
+            pos: Point { x: v[0], y: v[1] },
+            dim: Dimensions { width: v[2], height: v[3] },
+        }
+    }
+}
+
+impl From<Square> for Rectangle {
+    /// Convert a square into a rectangle.
+    fn from(s: Square) -> Rectangle {
+        Rectangle {
+            pos: s.pos,
+            dim: Dimensions { width: s.len, height: s.len },
+        }
+    }
+}
+
+impl Rectangle {
+    /// Returns the position of the bottom side of the rectangle.
+    pub fn bottom(&self) -> Scalar {
+        self.pos.y + self.dim.height
+    }
+
+    /// Computes a rectangle with quadruple the surface area of self and with center
+    /// (self.x, self.y).
+    pub fn centered(&self) -> Rectangle {
+        Rectangle {
+            pos: Point {
+                 x: self.pos.x - self.dim.width,
+                 y: self.pos.y - self.dim.height,
+            },
+            dim: 2.0 * self.dim,
+        }
+    }
+
+    /// Compute whether or not the point is inside the rectangle.
+    #[inline]
+    pub fn contains(&self, point: Point) -> bool {
+        self.left() < point.x && point.x < self.right() &&
+        self.top() < point.y && point.y < self.bottom()
+    }
+
+    /// Converts a rectangle into an array.
+    pub fn into_vec(self) -> [Scalar; 4] {
+        [self.pos.x, self.pos.y, self.dim.width, self.dim.height]
+    }
+
+    /// Returns the position of the left side of the rectangle.
+    pub fn left(&self) -> Scalar {
+        self.pos.x
+    }
+
+    /// Computes a rectangle whose perimeter forms the inside edge of margin with size m for self.
+    #[inline(always)]
+    pub fn margin(&self, m: Scalar) -> Rectangle {
+        let w = self.dim.width - 2.0 * m;
+        let h = self.dim.height - 2.0 * m;
+        let (x, w)
+            =   if w < 0.0 {
+                    (self.pos.x + 0.5 * self.dim.width, 0.0)
+                } else {
+                    (self.pos.x + m, w)
+                };
+        let (y, h)
+            =   if h < 0.0 {
+                    (self.pos.y + 0.5 * self.dim.height, 0.0)
+                } else {
+                    (self.pos.y + m, h)
+                };
+
+        Rectangle {
+            pos: Point { x: x, y: y },
+            dim: Dimensions { width: w, height: h },
+        }
+    }
+
+    /// Computes a rectangle translated (slid) in the direction of the vector a distance relative
+    /// to the size of the rectangle. For example, self.relative([1.0, 1.0]) returns a rectangle
+    /// one rectangle to the right and down from the original.
+    #[inline(always)]
+    pub fn relative(&self, v: Vec2d) -> Rectangle {
+        Rectangle {
+            pos: self.pos + (self.dim * v).to_vec(),
+            dim: self.dim,
+        }
+    }
+
+    /// Returns the position of the right side of the rectangle.
+    pub fn right(&self) -> Scalar {
+        self.pos.x + self.dim.width
+    }
+
+    /// Computes a scaled rectangle with the same position as self.
+    pub fn scaled(&self, v: Vec2d) -> Rectangle {
+        Rectangle {
+            pos: self.pos,
+            dim: self.dim * v,
+        }
+    }
+
+    /// Converts a rectangle into a Vec4<Scalar> representation.
+    pub fn to_vec(&self) -> [Scalar; 4] {
+        [self.pos.x, self.pos.y, self.dim.width, self.dim.height]
+    }
+
+    /// Returns the position of the top side of the rectangle.
+    pub fn top(&self) -> Scalar {
+        self.pos.y
+    }
+}
+
+/// A square.
+#[derive(Clone, Copy, Debug)]
+pub struct Square {
+    pos: Point,
+    len: Scalar,
+}

--- a/src/types_new.rs
+++ b/src/types_new.rs
@@ -7,8 +7,10 @@ pub use math::{ Matrix2d, Scalar, Vec2d };
 /// The size of a shape.
 #[derive(Clone, Copy, Debug)]
 pub struct Size {
-    width: Scalar,
-    height: Scalar,
+    /// The horizontal length of the shape.
+    pub width: Scalar,
+    /// The vertical length of the shape.
+    pub height: Scalar,
 }
 
 impl From<Vec2d> for Size {
@@ -43,8 +45,10 @@ impl Mul<Scalar> for Size {
 /// A point in the Cartesian plane.
 #[derive(Clone, Copy, Debug)]
 pub struct Point {
-    x: Scalar,
-    y: Scalar,
+    /// The x coordinate.
+    pub x: Scalar,
+    /// The y coordinate.
+    pub y: Scalar,
 }
 
 impl Add<Scalar> for Point {
@@ -92,11 +96,13 @@ impl Point {
     }
 }
 
-/// A rectangle whose top left corner is at pos.
+/// A rectangle.
 #[derive(Clone, Copy, Debug)]
 pub struct Rect {
-    pos: Point,
-    size: Size,
+    /// The position of the top left corner of the rectangle.
+    pub pos: Point,
+    /// The width and height of the rectangle.
+    pub size: Size,
 }
 
 impl From<(Point, Size)> for Rect {

--- a/src/types_new.rs
+++ b/src/types_new.rs
@@ -7,22 +7,22 @@ pub use math::{ Matrix2d, Scalar, Vec2d };
 /// The size of a shape.
 #[derive(Clone, Copy, Debug)]
 pub struct Size {
-    /// The horizontal length of the shape.
-    pub width: Scalar,
-    /// The vertical length of the shape.
-    pub height: Scalar,
+    /// The horizontal length of the shape (width).
+    pub w: Scalar,
+    /// The vertical length of the shape (height).
+    pub h: Scalar,
 }
 
 impl From<Vec2d> for Size {
     fn from(v: Vec2d) -> Size {
-        Size { width: v[0], height: v[1] }
+        Size { w: v[0], h: v[1] }
     }
 }
 
 impl Size {
     /// Convert size to a vector.
     pub fn to_vec2d(&self) -> Vec2d {
-        [self.width, self.height]
+        [self.w, self.h]
     }
 }
 
@@ -30,7 +30,7 @@ impl Mul<Vec2d> for Size {
     type Output = Size;
 
     fn mul(self, v: Vec2d) -> Size {
-        Size { width: self.width * v[0], height: self.height * v[1] }
+        Size { w: self.w * v[0], h: self.h * v[1] }
     }
 }
 
@@ -38,7 +38,7 @@ impl Mul<Scalar> for Size {
     type Output = Size;
 
     fn mul(self, s: Scalar) -> Size {
-        Size { width: self.width * s, height: self.height * s }
+        Size { w: self.w * s, h: self.h * s }
     }
 }
 
@@ -118,7 +118,7 @@ impl From<[Scalar; 4]> for Rect {
     fn from(v: [Scalar; 4]) -> Rect {
         Rect {
             pos: Point { x: v[0], y: v[1] },
-            size: Size { width: v[2], height: v[3] },
+            size: Size { w: v[2], h: v[3] },
         }
     }
 }
@@ -126,7 +126,7 @@ impl From<[Scalar; 4]> for Rect {
 impl Rect {
     /// Returns the position of the bottom side of the rectangle.
     pub fn bottom(&self) -> Scalar {
-        self.pos.y + self.size.height
+        self.pos.y + self.size.h
     }
 
     /// Computes a rectangle with quadruple the surface area of self and with center
@@ -134,8 +134,8 @@ impl Rect {
     pub fn centered(&self) -> Rect {
         Rect {
             pos: Point {
-                 x: self.pos.x - self.size.width,
-                 y: self.pos.y - self.size.height,
+                 x: self.pos.x - self.size.w,
+                 y: self.pos.y - self.size.h,
             },
             size: self.size * 2.0,
         }
@@ -156,8 +156,8 @@ impl Rect {
                 y: center.y - radius,
             },
             size: Size {
-                width: 2.0 * radius,
-                height: 2.0 * radius,
+                w: 2.0 * radius,
+                h: 2.0 * radius,
             },
         }
     }
@@ -166,13 +166,13 @@ impl Rect {
     pub fn from_square(pos: Point, len: Scalar) -> Rect {
         Rect {
             pos: pos,
-            size: Size { width: len, height: len },
+            size: Size { w: len, h: len },
         }
     }
 
     /// Converts a rectangle into [x, y, w, h].
     pub fn into_array(self) -> [Scalar; 4] {
-        [self.pos.x, self.pos.y, self.size.width, self.size.height]
+        [self.pos.x, self.pos.y, self.size.w, self.size.h]
     }
 
     /// Returns the position of the left side of the rectangle.
@@ -183,24 +183,24 @@ impl Rect {
     /// Computes a rectangle whose perimeter forms the inside edge of margin with size m for self.
     #[inline(always)]
     pub fn margin(&self, m: Scalar) -> Rect {
-        let w = self.size.width - 2.0 * m;
-        let h = self.size.height - 2.0 * m;
+        let w = self.size.w - 2.0 * m;
+        let h = self.size.h - 2.0 * m;
         let (x, w)
             =   if w < 0.0 {
-                    (self.pos.x + 0.5 * self.size.width, 0.0)
+                    (self.pos.x + 0.5 * self.size.w, 0.0)
                 } else {
                     (self.pos.x + m, w)
                 };
         let (y, h)
             =   if h < 0.0 {
-                    (self.pos.y + 0.5 * self.size.height, 0.0)
+                    (self.pos.y + 0.5 * self.size.h, 0.0)
                 } else {
                     (self.pos.y + m, h)
                 };
 
         Rect {
             pos: Point { x: x, y: y },
-            size: Size { width: w, height: h },
+            size: Size { w: w, h: h },
         }
     }
 
@@ -217,7 +217,7 @@ impl Rect {
 
     /// Returns the position of the right side of the rectangle.
     pub fn right(&self) -> Scalar {
-        self.pos.x + self.size.width
+        self.pos.x + self.size.w
     }
 
     /// Computes a scaled rectangle with the same position as self.
@@ -230,7 +230,7 @@ impl Rect {
 
     /// Converts a rectangle to [x, y, w, h].
     pub fn to_array(&self) -> [Scalar; 4] {
-        [self.pos.x, self.pos.y, self.size.width, self.size.height]
+        [self.pos.x, self.pos.y, self.size.w, self.size.h]
     }
 
     /// Returns the position of the top side of the rectangle.

--- a/src/types_new.rs
+++ b/src/types_new.rs
@@ -11,39 +11,39 @@ pub struct Circle {
     radius: Scalar,
 }
 
-/// The dimensions of a shape.
+/// The size of a shape.
 #[derive(Clone, Copy, Debug)]
-pub struct Dimensions {
+pub struct Size {
     width: Scalar,
     height: Scalar,
 }
 
-impl From<Vec2d> for Dimensions {
-    fn from(v: Vec2d) -> Dimensions {
-        Dimensions { width: v[0], height: v[1] }
+impl From<Vec2d> for Size {
+    fn from(v: Vec2d) -> Size {
+        Size { width: v[0], height: v[1] }
     }
 }
 
-impl Dimensions {
-    /// Convert dimenions to a vector.
-    pub fn to_vec(&self) -> Vec2d {
+impl Size {
+    /// Convert size to a vector.
+    pub fn to_vec2d(&self) -> Vec2d {
         [self.width, self.height]
     }
 }
 
-impl Mul<Vec2d> for Dimensions {
-    type Output = Dimensions;
+impl Mul<Vec2d> for Size {
+    type Output = Size;
 
-    fn mul(self, v: Vec2d) -> Dimensions {
-        Dimensions { width: self.width * v[0], height: self.height * v[1] }
+    fn mul(self, v: Vec2d) -> Size {
+        Size { width: self.width * v[0], height: self.height * v[1] }
     }
 }
 
-impl Mul<Scalar> for Dimensions {
-    type Output = Dimensions;
+impl Mul<Scalar> for Size {
+    type Output = Size;
 
-    fn mul(self, s: Scalar) -> Dimensions {
-        Dimensions { width: self.width * s, height: self.height * s }
+    fn mul(self, s: Scalar) -> Size {
+        Size { width: self.width * s, height: self.height * s }
     }
 }
 
@@ -94,27 +94,27 @@ impl Sub<Vec2d> for Point {
 
 impl Point {
     /// Convert the point to a vector.
-    pub fn to_vec(&self) -> Vec2d {
+    pub fn to_vec2d(&self) -> Vec2d {
         [self.x, self.y]
     }
 }
 
-/// A rectangle whose top left corner is at (x, y).
+/// A rectangle whose top left corner is at pos.
 #[derive(Clone, Copy, Debug)]
-pub struct Rectangle {
+pub struct Rect {
     pos: Point,
-    dim: Dimensions,
+    size: Size,
 }
 
-impl From<Circle> for Rectangle {
+impl From<Circle> for Rect {
     /// Convert from a circle to a rectangle.
-    fn from(c: Circle) -> Rectangle {
-        Rectangle {
+    fn from(c: Circle) -> Rect {
+        Rect {
             pos: Point {
                 x: c.center.x - c.radius,
                 y: c.center.y - c.radius,
             },
-            dim: Dimensions {
+            size: Size {
                 width: 2.0 * c.radius,
                 height: 2.0 * c.radius,
             },
@@ -122,49 +122,49 @@ impl From<Circle> for Rectangle {
     }
 }
 
-impl From<(Point, Dimensions)> for Rectangle {
-    /// Creates a rectangle from the position of its top left corner and its dimensions.
-    fn from(rectangle: (Point, Dimensions)) -> Rectangle {
-        let (pos, dim) = rectangle;
-        Rectangle { pos: pos, dim: dim }
+impl From<(Point, Size)> for Rect {
+    /// Creates a rectangle from the position of its top left corner and its size.
+    fn from(rectangle: (Point, Size)) -> Rect {
+        let (pos, size) = rectangle;
+        Rect { pos: pos, size: size }
     }
 }
 
-impl From<[Scalar; 4]> for Rectangle {
+impl From<[Scalar; 4]> for Rect {
     /// Creates a rectangle from an array.
-    fn from(v: [Scalar; 4]) -> Rectangle {
-        Rectangle {
+    fn from(v: [Scalar; 4]) -> Rect {
+        Rect {
             pos: Point { x: v[0], y: v[1] },
-            dim: Dimensions { width: v[2], height: v[3] },
+            size: Size { width: v[2], height: v[3] },
         }
     }
 }
 
-impl From<Square> for Rectangle {
+impl From<Square> for Rect {
     /// Convert a square into a rectangle.
-    fn from(s: Square) -> Rectangle {
-        Rectangle {
+    fn from(s: Square) -> Rect {
+        Rect {
             pos: s.pos,
-            dim: Dimensions { width: s.len, height: s.len },
+            size: Size { width: s.len, height: s.len },
         }
     }
 }
 
-impl Rectangle {
+impl Rect {
     /// Returns the position of the bottom side of the rectangle.
     pub fn bottom(&self) -> Scalar {
-        self.pos.y + self.dim.height
+        self.pos.y + self.size.height
     }
 
     /// Computes a rectangle with quadruple the surface area of self and with center
     /// (self.x, self.y).
-    pub fn centered(&self) -> Rectangle {
-        Rectangle {
+    pub fn centered(&self) -> Rect {
+        Rect {
             pos: Point {
-                 x: self.pos.x - self.dim.width,
-                 y: self.pos.y - self.dim.height,
+                 x: self.pos.x - self.size.width,
+                 y: self.pos.y - self.size.height,
             },
-            dim: self.dim * 2.0,
+            size: self.size * 2.0,
         }
     }
 
@@ -175,9 +175,9 @@ impl Rectangle {
         self.top() < point.y && point.y < self.bottom()
     }
 
-    /// Converts a rectangle into an array.
-    pub fn into_vec(self) -> [Scalar; 4] {
-        [self.pos.x, self.pos.y, self.dim.width, self.dim.height]
+    /// Converts a rectangle into [x, y, w, h].
+    pub fn into_array(self) -> [Scalar; 4] {
+        [self.pos.x, self.pos.y, self.size.width, self.size.height]
     }
 
     /// Returns the position of the left side of the rectangle.
@@ -187,25 +187,25 @@ impl Rectangle {
 
     /// Computes a rectangle whose perimeter forms the inside edge of margin with size m for self.
     #[inline(always)]
-    pub fn margin(&self, m: Scalar) -> Rectangle {
-        let w = self.dim.width - 2.0 * m;
-        let h = self.dim.height - 2.0 * m;
+    pub fn margin(&self, m: Scalar) -> Rect {
+        let w = self.size.width - 2.0 * m;
+        let h = self.size.height - 2.0 * m;
         let (x, w)
             =   if w < 0.0 {
-                    (self.pos.x + 0.5 * self.dim.width, 0.0)
+                    (self.pos.x + 0.5 * self.size.width, 0.0)
                 } else {
                     (self.pos.x + m, w)
                 };
         let (y, h)
             =   if h < 0.0 {
-                    (self.pos.y + 0.5 * self.dim.height, 0.0)
+                    (self.pos.y + 0.5 * self.size.height, 0.0)
                 } else {
                     (self.pos.y + m, h)
                 };
 
-        Rectangle {
+        Rect {
             pos: Point { x: x, y: y },
-            dim: Dimensions { width: w, height: h },
+            size: Size { width: w, height: h },
         }
     }
 
@@ -213,29 +213,29 @@ impl Rectangle {
     /// to the size of the rectangle. For example, self.relative([1.0, 1.0]) returns a rectangle
     /// one rectangle to the right and down from the original.
     #[inline(always)]
-    pub fn relative(&self, v: Vec2d) -> Rectangle {
-        Rectangle {
-            pos: self.pos + (self.dim * v).to_vec(),
-            dim: self.dim,
+    pub fn relative(&self, v: Vec2d) -> Rect {
+        Rect {
+            pos: self.pos + (self.size * v).to_vec2d(),
+            size: self.size,
         }
     }
 
     /// Returns the position of the right side of the rectangle.
     pub fn right(&self) -> Scalar {
-        self.pos.x + self.dim.width
+        self.pos.x + self.size.width
     }
 
     /// Computes a scaled rectangle with the same position as self.
-    pub fn scaled(&self, v: Vec2d) -> Rectangle {
-        Rectangle {
+    pub fn scaled(&self, v: Vec2d) -> Rect {
+        Rect {
             pos: self.pos,
-            dim: self.dim * v,
+            size: self.size * v,
         }
     }
 
-    /// Converts a rectangle into a Vec4<Scalar> representation.
-    pub fn to_vec(&self) -> [Scalar; 4] {
-        [self.pos.x, self.pos.y, self.dim.width, self.dim.height]
+    /// Converts a rectangle to [x, y, w, h].
+    pub fn to_array(&self) -> [Scalar; 4] {
+        [self.pos.x, self.pos.y, self.size.width, self.size.height]
     }
 
     /// Returns the position of the top side of the rectangle.

--- a/src/types_new.rs
+++ b/src/types_new.rs
@@ -4,13 +4,6 @@ use std::ops::{ Add, Mul, Sub };
 
 pub use math::{ Matrix2d, Scalar, Vec2d };
 
-/// A circle.
-#[derive(Clone, Copy, Debug)]
-pub struct Circle {
-    center: Point,
-    radius: Scalar,
-}
-
 /// The size of a shape.
 #[derive(Clone, Copy, Debug)]
 pub struct Size {
@@ -106,22 +99,6 @@ pub struct Rect {
     size: Size,
 }
 
-impl From<Circle> for Rect {
-    /// Convert from a circle to a rectangle.
-    fn from(c: Circle) -> Rect {
-        Rect {
-            pos: Point {
-                x: c.center.x - c.radius,
-                y: c.center.y - c.radius,
-            },
-            size: Size {
-                width: 2.0 * c.radius,
-                height: 2.0 * c.radius,
-            },
-        }
-    }
-}
-
 impl From<(Point, Size)> for Rect {
     /// Creates a rectangle from the position of its top left corner and its size.
     fn from(rectangle: (Point, Size)) -> Rect {
@@ -136,16 +113,6 @@ impl From<[Scalar; 4]> for Rect {
         Rect {
             pos: Point { x: v[0], y: v[1] },
             size: Size { width: v[2], height: v[3] },
-        }
-    }
-}
-
-impl From<Square> for Rect {
-    /// Convert a square into a rectangle.
-    fn from(s: Square) -> Rect {
-        Rect {
-            pos: s.pos,
-            size: Size { width: s.len, height: s.len },
         }
     }
 }
@@ -173,6 +140,28 @@ impl Rect {
     pub fn contains(&self, point: Point) -> bool {
         self.left() < point.x && point.x < self.right() &&
         self.top() < point.y && point.y < self.bottom()
+    }
+
+    /// Create a rectangle that circumscribes the given circle.
+    pub fn from_circle(center: Point, radius: Scalar) -> Rect {
+        Rect {
+            pos: Point {
+                x: center.x - radius,
+                y: center.y - radius,
+            },
+            size: Size {
+                width: 2.0 * radius,
+                height: 2.0 * radius,
+            },
+        }
+    }
+
+    /// Create a square rectangle with sides of length len and top left corner at pos.
+    pub fn from_square(pos: Point, len: Scalar) -> Rect {
+        Rect {
+            pos: pos,
+            size: Size { width: len, height: len },
+        }
     }
 
     /// Converts a rectangle into [x, y, w, h].
@@ -242,11 +231,4 @@ impl Rect {
     pub fn top(&self) -> Scalar {
         self.pos.y
     }
-}
-
-/// A square.
-#[derive(Clone, Copy, Debug)]
-pub struct Square {
-    pos: Point,
-    len: Scalar,
 }


### PR DESCRIPTION
Suggested way that Rectangle could be made a struct taking into consideration the types in conrod and how rectangles are used there. The hope is to reuse the structure in conrod.

CC #882 