### PR TITLE
Some minor tweaks to the new types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-graphics"
-version = "0.0.34"
+version = "0.0.35"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/types_new.rs
+++ b/src/types_new.rs
@@ -2,7 +2,7 @@
 use std::convert::From;
 use std::ops::{ Add, Mul, Sub };
 
-pub use math::{ Matrix2d, Scalar, Vec2d };
+pub use math::{ self, Matrix2d, Scalar, Vec2d };
 
 /// The size of a shape.
 #[derive(Clone, Copy, Debug)]
@@ -19,18 +19,25 @@ impl From<Vec2d> for Size {
     }
 }
 
+impl From<(Scalar, Scalar)> for Size {
+    fn from((w, h): (Scalar, Scalar)) -> Size {
+        Size { w: w, h: h }
+    }
+}
+
 impl Size {
     /// Convert size to a vector.
-    pub fn to_vec2d(&self) -> Vec2d {
+    pub fn to_array(self) -> Vec2d {
         [self.w, self.h]
     }
 }
 
-impl Mul<Vec2d> for Size {
+impl<T: Into<Size>> Mul<T> for Size {
     type Output = Size;
 
-    fn mul(self, v: Vec2d) -> Size {
-        Size { w: self.w * v[0], h: self.h * v[1] }
+    fn mul(self, v: T) -> Size {
+        let v: Size = v.into();
+        Size { w: self.w * v.w, h: self.h * v.h }
     }
 }
 
@@ -59,17 +66,24 @@ impl Add<Scalar> for Point {
     }
 }
 
-impl Add<Vec2d> for Point {
+impl<T: Into<Point>> Add<T> for Point {
     type Output = Point;
 
-    fn add(self, v: Vec2d) -> Point {
-        Point { x: self.x + v[0], y: self.y + v[1] }
+    fn add(self, v: T) -> Point {
+        let v: Point = v.into();
+        Point { x: self.x + v.x, y: self.y + v.y }
     }
 }
 
 impl From<Vec2d> for Point {
     fn from(v: Vec2d) -> Point {
         Point { x: v[0], y: v[1] }
+    }
+}
+
+impl From<(Scalar, Scalar)> for Point {
+    fn from((x, y): (Scalar, Scalar)) -> Point {
+        Point { x: x, y: y }
     }
 }
 
@@ -81,17 +95,18 @@ impl Sub<Scalar> for Point {
     }
 }
 
-impl Sub<Vec2d> for Point {
+impl<T: Into<Point>> Sub<T> for Point {
     type Output = Point;
 
-    fn sub(self, v: Vec2d) -> Point {
-        Point { x: self.x - v[0], y: self.y - v[1] }
+    fn sub(self, v: T) -> Point {
+        let v = v.into();
+        Point { x: self.x - v.x, y: self.y - v.y }
     }
 }
 
 impl Point {
     /// Convert the point to a vector.
-    pub fn to_vec2d(&self) -> Vec2d {
+    pub fn to_array(self) -> Vec2d {
         [self.x, self.y]
     }
 }
@@ -105,10 +120,10 @@ pub struct Rect {
     pub size: Size,
 }
 
-impl From<(Point, Size)> for Rect {
+impl<P: Into<Point>, S: Into<Size>> From<(P, S)> for Rect {
     /// Creates a rectangle from the position of its top left corner and its size.
-    fn from(rectangle: (Point, Size)) -> Rect {
-        let (pos, size) = rectangle;
+    fn from((pos, size): (P, S)) -> Rect {
+        let (pos, size): (Point, Size) = (pos.into(), size.into());
         Rect { pos: pos, size: size }
     }
 }
@@ -123,6 +138,15 @@ impl From<[Scalar; 4]> for Rect {
     }
 }
 
+impl From<(Scalar, Scalar, Scalar, Scalar)> for Rect {
+    fn from((x, y, w, h): (Scalar, Scalar, Scalar, Scalar)) -> Rect {
+        Rect {
+            pos: Point { x: x, y: y },
+            size: Size { w: w, h: h },
+        }
+    }
+}
+
 impl Rect {
     /// Returns the position of the bottom side of the rectangle.
     pub fn bottom(&self) -> Scalar {
@@ -131,7 +155,7 @@ impl Rect {
 
     /// Computes a rectangle with quadruple the surface area of self and with center
     /// (self.x, self.y).
-    pub fn centered(&self) -> Rect {
+    pub fn centered(self) -> Rect {
         Rect {
             pos: Point {
                  x: self.pos.x - self.size.w,
@@ -142,14 +166,16 @@ impl Rect {
     }
 
     /// Compute whether or not the point is inside the rectangle.
-    #[inline]
-    pub fn contains(&self, point: Point) -> bool {
+    #[inline(always)]
+    pub fn contains<T: Into<Point>>(&self, point: T) -> bool {
+        let point: Point = point.into();
         self.left() < point.x && point.x < self.right() &&
         self.top() < point.y && point.y < self.bottom()
     }
 
     /// Create a rectangle that circumscribes the given circle.
-    pub fn new_circle(center: Point, radius: Scalar) -> Rect {
+    pub fn new_circle<T: Into<Point>>(center: T, radius: Scalar) -> Rect {
+        let center: Point = center.into();
         Rect {
             pos: Point {
                 x: center.x - radius,
@@ -163,16 +189,12 @@ impl Rect {
     }
 
     /// Create a square rectangle with sides of length len and top left corner at pos.
-    pub fn new_square(pos: Point, len: Scalar) -> Rect {
+    pub fn new_square<T: Into<Point>>(pos: T, len: Scalar) -> Rect {
+        let pos: Point = pos.into();
         Rect {
             pos: pos,
             size: Size { w: len, h: len },
         }
-    }
-
-    /// Converts a rectangle into [x, y, w, h].
-    pub fn into_array(self) -> [Scalar; 4] {
-        [self.pos.x, self.pos.y, self.size.w, self.size.h]
     }
 
     /// Returns the position of the left side of the rectangle.
@@ -182,35 +204,21 @@ impl Rect {
 
     /// Computes a rectangle whose perimeter forms the inside edge of margin with size m for self.
     #[inline(always)]
-    pub fn margin(&self, m: Scalar) -> Rect {
-        let w = self.size.w - 2.0 * m;
-        let h = self.size.h - 2.0 * m;
-        let (x, w)
-            =   if w < 0.0 {
-                    (self.pos.x + 0.5 * self.size.w, 0.0)
-                } else {
-                    (self.pos.x + m, w)
-                };
-        let (y, h)
-            =   if h < 0.0 {
-                    (self.pos.y + 0.5 * self.size.h, 0.0)
-                } else {
-                    (self.pos.y + m, h)
-                };
-
-        Rect {
-            pos: Point { x: x, y: y },
-            size: Size { w: w, h: h },
-        }
+    pub fn margin(self, m: Scalar) -> Rect {
+        math::margin_rectangle(self.to_array(), m).into()
     }
 
     /// Computes a rectangle translated (slid) in the direction of the vector a distance relative
     /// to the size of the rectangle. For example, self.relative([1.0, 1.0]) returns a rectangle
     /// one rectangle to the right and down from the original.
     #[inline(always)]
-    pub fn relative(&self, v: Vec2d) -> Rect {
+    pub fn relative<T: Into<Point>>(self, v: T) -> Rect {
+        let v: Point = v.into();
         Rect {
-            pos: self.pos + (self.size * v).to_vec2d(),
+            pos: Point {
+                x: self.pos.x + self.size.w * v.x,
+                y: self.pos.y + self.size.h * v.y,
+            },
             size: self.size,
         }
     }
@@ -221,7 +229,8 @@ impl Rect {
     }
 
     /// Computes a scaled rectangle with the same position as self.
-    pub fn scaled(&self, v: Vec2d) -> Rect {
+    pub fn scaled<T: Into<Size>>(self, v: T) -> Rect {
+        let v: Size = v.into();
         Rect {
             pos: self.pos,
             size: self.size * v,
@@ -229,7 +238,7 @@ impl Rect {
     }
 
     /// Converts a rectangle to [x, y, w, h].
-    pub fn to_array(&self) -> [Scalar; 4] {
+    pub fn to_array(self) -> [Scalar; 4] {
         [self.pos.x, self.pos.y, self.size.w, self.size.h]
     }
 


### PR DESCRIPTION
* Added conversion from tuples
* Renamed `to_vec2d` to `to_array`
* Take `self` when returning `Self` or converting
* More flexible operator overloading
* Use conversion traits when possible
* Reuse `math::margin_rectangle`