### PR TITLE
Added graphics::arc for drawing arcs of a circle/ellipse.

### DIFF
--- a/src/circle_arc.rs
+++ b/src/circle_arc.rs
@@ -1,0 +1,109 @@
+//! Draw an arc
+
+use { triangulation, DrawState, Graphics };
+use math::Matrix2d;
+
+use types::{ Color, Radius, Rectangle, Resolution, Scalar };
+
+/// A curved line
+#[derive(Copy, Clone)]
+pub struct CircleArc {
+
+    /// The arcs color
+    pub color: Color,
+
+    /// The radius of the arc (Thickness of the drawing, not the radius of the circle)
+    pub radius: Radius,
+
+    /// The start of the arc in radians
+    pub start: Scalar,
+
+    /// The end of the arc in radians
+    pub end: Scalar,
+
+    /// The resolution for the arc.
+    pub resolution: Resolution,
+}
+
+impl CircleArc {
+    /// Creates a new arc
+    pub fn new(color: Color, radius: Radius, start: Scalar, end: Scalar) -> CircleArc {
+        CircleArc {
+            color: color,
+            radius: radius,
+            start: start,
+            end: end,
+            resolution: 128,
+        }
+    }
+
+    /// Sets the arcs color.
+    pub fn color(mut self, value: Color) -> Self {
+        self.color = value;
+        self
+    }
+
+    /// Sets the radius of the arc (Thickness of the arc, not the radius of the circle it wraps)
+    pub fn radius(mut self, value: Radius) -> Self {
+        self.radius = value;
+        self
+    }
+
+    /// Sets the start of the arc (in radians).
+    pub fn start(mut self, value: Scalar) -> Self {
+        self.start = value;
+        self
+    }
+
+    /// Sets the end of the arc (in radians).
+    pub fn end(mut self, value: Scalar) -> Self {
+        self.end = value;
+        self
+    }
+
+    /// Sets the resolution of the arcs smoothness.
+    pub fn resolution(mut self, value: Resolution) -> Self {
+        self.resolution = value;
+        self
+    }
+
+    /// Draws the arc.
+    pub fn draw<R: Into<Rectangle>, G>(
+        &self,
+        rectangle: R,
+        draw_state: &DrawState,
+        transform: Matrix2d,
+        g: &mut G
+    )
+        where G: Graphics
+    {
+        let rectangle = rectangle.into();
+        g.tri_list(
+            &draw_state,
+            &self.color,
+            |f|
+        triangulation::with_arc_tri_list(
+            self.start,
+            self.end,
+            self.resolution,
+            transform,
+            rectangle,
+            self.radius,
+            |vertices| f(vertices)
+        ));
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_circle_arc() {
+        let _arc = CircleArc::new([1.0; 4], 4.0, 0.0, ::std::f64::consts::PI)
+            .color([0.0; 4])
+            .radius(4.0)
+            .start(::std::f64::consts::PI * 0.25)
+            .end(::std::f64::consts::PI * 1.25);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub use colored::Colored;
 pub use rectangle::Rectangle;
 pub use line::Line;
 pub use ellipse::Ellipse;
+pub use circle_arc::CircleArc;
 pub use image::Image;
 pub use polygon::Polygon;
 pub use text::Text;
@@ -53,6 +54,7 @@ pub mod context;
 pub mod color;
 pub mod polygon;
 pub mod line;
+pub mod circle_arc;
 pub mod ellipse;
 pub mod rectangle;
 pub mod image;
@@ -100,6 +102,21 @@ pub fn ellipse<R: Into<types::Rectangle>, G>(
     where G: Graphics
 {
     Ellipse::new(color).draw(rect, default_draw_state(), transform, g);
+}
+
+/// Draws arc
+pub fn circle_arc<R: Into<types::Rectangle>, G>(
+    color: types::Color,
+    radius: types::Radius,
+    start: types::Scalar,
+    end: types::Scalar,
+    rect: R,
+    transform: math::Matrix2d,
+    g: &mut G
+)
+    where G: Graphics
+{
+    CircleArc::new(color, radius, start, end).draw(rect, default_draw_state(), transform, g);
 }
 
 /// Draws rectangle.

--- a/src/triangulation.rs
+++ b/src/triangulation.rs
@@ -324,6 +324,49 @@ pub fn with_ellipse_border_tri_list<F>(
     }, f);
 }
 
+/// Streams an arc between the two radian boundaries.
+#[inline(always)]
+pub fn with_arc_tri_list<F>(
+    start_radians: Scalar,
+    end_radians: Scalar,
+    resolution: Resolution,
+    m: Matrix2d,
+    rect: Rectangle,
+    border_radius: Radius,
+    f: F
+)
+    where
+        F: FnMut(&[f32])
+{
+
+    let (x, y, w, h) = (rect[0], rect[1], rect[2], rect[3]);
+    let (cw, ch) = (0.5 * w, 0.5 * h);
+    let (cw1, ch1) = (cw + border_radius, ch + border_radius);
+    let (cw2, ch2) = (cw - border_radius, ch - border_radius);
+    let (cx, cy) = (x + cw, y + ch);
+    let n = resolution;
+    let mut i = 0;
+    let (nearest_start_radians, nearest_end_radians) = if start_radians < end_radians {
+        (start_radians, start_radians + (end_radians - start_radians))
+    } else {
+        (end_radians, end_radians + (start_radians - end_radians))
+    };
+    stream_quad_tri_list(m, || {
+        if i > n { return None; }
+
+        let angle = nearest_start_radians + i as Scalar / n as Scalar * <f64 as Radians>::_360();
+        if angle > nearest_end_radians {
+            return None;
+        }
+
+        let cos = angle.cos();
+        let sin = angle.sin();
+        i += 1;
+        Some(([cx + cos * cw1, cy + sin * ch1],
+            [cx + cos * cw2, cy + sin * ch2]))
+    }, f);
+}
+
 /// Streams a round rectangle border.
 #[inline(always)]
 pub fn with_round_rectangle_border_tri_list<F>(


### PR DESCRIPTION
Adds the ability to draw an arc. Implemented very similarly to how an ellipse is rendered. Given that I don't entirely understand how `with_ellipse_border_tri_list` and `stream_quad_tri_list` work, its likely there can be improvements made on this. (And I would greatly appreciate any suggestions :smile: ).

I considered refactoring `with_ellipse_border_tri_list` to use `with_arc_tri_list`, always passing 0.0 and 2.0 * PI for start and end. A lot of code is duplicated between the two since I copied a large chunk of this from `with_arc_tri_list` from `with_ellipse_border_tri_list`.

Below is an example image and [here's a gist of the code I used to render it.](https://gist.github.com/echochamber/83f81156fbbf5b7e1546)

![screen shot 2015-08-18 at 5 12 36 pm](https://cloud.githubusercontent.com/assets/4073509/9346039/6db95f58-45cc-11e5-80de-26e1b7e162c4.png)
