### PR TITLE
Removed unneeded dependency on num (again)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-graphics"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",
@@ -24,7 +24,6 @@ path = "./src/lib.rs"
 [dependencies]
 draw_state = "0.2.0"
 interpolation = "0.1.0"
-num = "0.1.25"
 piston-texture = "0.2.1"
 piston-viewport = "0.1.0"
 read_color = "0.1.0"


### PR DESCRIPTION
This was removed before in
https://github.com/PistonDevelopers/graphics/commit/c814a6786cc2dfad10d4
bf2133fca0551d540e34#diff-80398c5faae3c069e4e6aa2ed11b28c0, but somehow
sneaked back in
https://github.com/PistonDevelopers/graphics/commit/c02c93aae8a9c12576ab
fe93358fd4bbdd822525#diff-80398c5faae3c069e4e6aa2ed11b28c0. The line is
not marked as added, so something weird must have happened.