### PR TITLE
Added method for rounding the position of Text in draw (to avoid aliasing). Closes #998.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-graphics"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/text.rs
+++ b/src/text.rs
@@ -12,6 +12,8 @@ pub struct Text {
     pub color: Color,
     /// The font size
     pub font_size: FontSize,
+    /// Whether or not the text's position should be rounded (to a signed distance field).
+    pub round: bool,
 }
 
 impl Text {
@@ -20,6 +22,7 @@ impl Text {
         Text {
             color: color::BLACK,
             font_size: font_size,
+            round: false,
         }
     }
 
@@ -31,7 +34,14 @@ impl Text {
         Text {
             color: color,
             font_size: font_size,
+            round: false,
         }
+    }
+
+    /// A builder method indicating that the Text's position should be rounded upon drawing.
+    pub fn round(mut self) -> Text {
+        self.round = true;
+        self
     }
 
     /// Draws text with a character cache
@@ -52,14 +62,13 @@ impl Text {
         let mut y = 0.0;
         for ch in text.chars() {
             let character = cache.character(self.font_size, ch);
-            image.draw(&character.texture,
-                draw_state,
-                transform.trans(
-                    x + character.left(),
-                    y - character.top()
-                ),
-                g
-            );
+            let mut ch_x = x + character.left();
+            let mut ch_y = y - character.top();
+            if self.round {
+                ch_x = ch_x.round();
+                ch_y = ch_y.round();
+            }
+            image.draw(&character.texture, draw_state, transform.trans(ch_x, ch_y), g);
             x += character.width();
             y += character.height();
         }


### PR DESCRIPTION
This should fix some of the aliasing issues that were occurring in elmesque and in turn conrod. Conrod's all_widgets example now seems to be perfect on my regular display, however there are still some strange artefacts appearing when I run it on my retina display:

<img width="389" alt="screen shot 2015-09-08 at 12 46 50 am" src="https://cloud.githubusercontent.com/assets/4587373/9719382/1e7b8b22-55c7-11e5-8c06-75077f903caa.png">


I'm quite sure that these artefacts are unrelated to this PR though and are more likely something to do with the character's texture as the artefacts seem to line the edges of their bounding rects (I'll open a separate issue).

This PR is a breaking change due to the added `round` field to the `Text`.

Closes #998.