### PR TITLE
Add methods to calculate on-screen positions of Grid cells

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -60,6 +60,21 @@ impl Grid {
             state: 0,
         }
     }
+    
+    /// Get on-screen position of a grid cell
+    pub fn cell_position(&self, cell: (u32, u32)) -> [f64; 2] {
+        [cell.0 as f64 * &self.units, cell.1 as f64 * &self.units]
+    }
+    
+    /// Get on-screen x position of a grid cell
+    pub fn x_pos(&self, cell: (u32, u32)) -> f64 {
+        self.cell_position(cell)[0]
+    }
+
+    /// Get on-screen y position of a grid cell
+    pub fn y_pos(&self, cell: (u32, u32)) -> f64 {
+        self.cell_position(cell)[1]
+    }
 }
 
 impl Iterator for GridCells {
@@ -93,5 +108,12 @@ mod tests {
         let expected: Vec<(u32, u32)> = vec![(0, 0), (1, 0), (0, 1), (1, 1)];
         let cells: Vec<(u32, u32)> = g.cells().collect();
         assert_eq!(expected, cells);
+    }
+
+    #[test]
+    fn test_cell_positions() {
+        let g: Grid = Grid {cols: 2, rows: 3, units: 2.0};
+        assert_eq!(4.0, g.x_pos((2,3)));
+        assert_eq!(6.0, g.y_pos((2,3)));
     }
 }


### PR DESCRIPTION
This pull request is my solution to issue #1013. I've added 3 new methods to the `Grid` struct. `cell_position()` takes a cell in the Grid, such as `(2, 2)` as an argument, and multiplies them by the unit size of the `Grid` to get the on-screen position of the cell at `(x, y)`. The `x_pos()` and `y_pos()` methods return only the position of the grid cell at `x` or `y` respectively. My reasoning for choosing u32 is that this is the type of of the `cols` and `rows` fields in the Grid struct, and in game programming we rarely, if ever deal with negative numbers on 2d square grids, so I felt that this was the appropriate choice for this project.

I've also included a test function that uses all 3 methods I've added, so that you can comfortably know that they've been unit tested. In addition, I'd like to include a picture of a little project of mine which has used these methods so I can demonstrate the usefulness:

![Image of Grid](http://i.imgur.com/AdqYu2Q.jpg)

This is a breadth first pathfinding algorithm (with early exit) in which I've used the methods to color each cell that was searched by the algorithm in red. I think having these methods built-in will make it easier for anyone who wants to write a roguelike or similar top-down 2D game, so that they can directly use the already-provided `Grid` object and its methods instead of having to rewrite their own.

Thank you,

Justin