### PR TITLE
Added conversion functions for gamma in sRGB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-graphics"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/color.rs
+++ b/src/color.rs
@@ -36,3 +36,47 @@ pub fn hex(hex: &str) -> Color {
         color[3] as f32 * inv_255
     ]
 }
+
+#[inline(always)]
+fn component_srgb_to_linear(f: ColorComponent) -> ColorComponent {
+    if f <= 0.04045 {
+        f / 12.92
+    } else {
+        ((f + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+/// Converts gamma (brightness) from sRGB to linear color space.
+///
+/// sRGB is the default color space for image editors, pictures, internet etc.
+/// Linear gamma yields better results when doing math with colors.
+pub fn gamma_srgb_to_linear(c: Color) -> Color {
+    [
+        component_srgb_to_linear(c[0]),
+        component_srgb_to_linear(c[1]),
+        component_srgb_to_linear(c[2]),
+        c[3]
+    ]
+}
+
+#[inline(always)]
+fn component_linear_to_srgb(f: ColorComponent) -> ColorComponent {
+    if f <= 0.0031308 {
+        f * 12.92
+    } else {
+        1.055 * f.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+/// Converts gamma (brightness) of a color from linear color space to sRGB.
+///
+/// sRGB is the default color space for image editors, pictures, internet etc.
+/// Linear gamma yields better results when doing math with colors.
+pub fn gamma_linear_to_srgb(c: Color) -> Color {
+    [
+        component_linear_to_srgb(c[0]),
+        component_linear_to_srgb(c[1]),
+        component_linear_to_srgb(c[2]),
+        c[3]
+    ]
+}

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -26,6 +26,17 @@ use {
 /// ```ignore
 /// fn draw<G: Graphics>(c: &Context, g: &mut G) { ... }
 /// ```
+///
+/// Color space is sRGB.
+///
+/// ### Notice for back-end authors
+///
+/// When sRGB is enabled for a back-end shader, the gamma must be converted
+/// to linear space when used as vertex color or uniform parameter.
+/// To convert gamma, use `color::gamma_srgb_to_linear`.
+///
+/// For more information, see
+/// https://github.com/PistonDevelopers/piston/issues/1014.
 pub trait Graphics: Sized {
     /// The texture type associated with the back-end.
     ///
@@ -44,6 +55,8 @@ pub trait Graphics: Sized {
     /// Clears background with a color.
     ///
     /// The color should replace the values in the buffer.
+    ///
+    /// Color space is sRGB.
     fn clear_color(&mut self, color: types::Color);
 
     /// Clears stencil buffer with a value, usually 0.
@@ -66,6 +79,8 @@ pub trait Graphics: Sized {
     /// The number of vertices per chunk never exceeds
     /// `BACK_END_MAX_VERTEX_COUNT`.
     /// Vertex positions are encoded `[x0, y0, x1, y1, ...]`.
+    ///
+    /// Color space is sRGB.
     fn tri_list<F>(&mut self, draw_state: &DrawState, color: &[f32; 4], f: F)
         where F: FnMut(&mut FnMut(&[f32]));
 
@@ -88,6 +103,8 @@ pub trait Graphics: Sized {
     ///
     /// Chunks uses separate buffer for vertex positions and texture coordinates.
     /// Arguments are `|vertices: &[f32], texture_coords: &[f32]`.
+    ///
+    /// Color space is sRGB.
     fn tri_list_uv<F>(
         &mut self,
         draw_state: &DrawState,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,30 @@
 #![deny(missing_copy_implementations)]
 
 //! A library for 2D graphics that works with multiple back-ends.
+//!
+//! Piston-Graphics was started in 2014 by Sven Nilsen to test
+//! back-end agnostic design for 2D in Rust.
+//! This means generic code can be reused across projects and platforms.
+//!
+//! ### Design
+//!
+//! A graphics back-end implements the `Graphics` trait.
+//!
+//! This library uses immediate design for flexibility.
+//! By default, triangles are generated from 2D shapes and passed in chunks
+//! to the back-end. This behavior can be overridden by a back-end library.
+//!
+//! The structures used for drawing 2D shapes contains settings for rendering.
+//! The separation of shapes and settings allows more reuse and flexibility.
+//! For example, to render an image, you use an `Image` object.
+//!
+//! The `math` module contains useful methods for 2D geometry.
+//!
+//! `Context` stores settings that are commonly shared when rendering.
+//! It can be copied and changed without affecting any global state.
+//!
+//! At top level, there are some shortcut methods for common operations.
+//! For example, `ellipse` is a simplified version of `Ellipse`.
 
 extern crate vecmath;
 extern crate texture;


### PR DESCRIPTION
- Bumped to 0.15.0
- Added `color::gamma_srgb_to_linear`
- Added `color::gamma_linear_to_srgb`
- Added notice for back-end authors on `Graphics` trait
- Added comments about color space to `Graphics` trait
- Improved docs