### PR TITLE
Update minor version for breaking change where re-exported ImageSize trait is bound to new version of texture.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-graphics"
-version = "0.16.1"
+version = "0.17.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",


### PR DESCRIPTION
Yanked **0.16.1** and published **0.17.0**.

Closes #1051.

