### PR TITLE
Fix different visual bug I introduced by fixing previous visual bug

### DIFF
--- a/src/triangulation.rs
+++ b/src/triangulation.rs
@@ -370,14 +370,12 @@ pub fn with_arc_tri_list<F>(
     let (cw2, ch2) = (cw - border_radius, ch - border_radius);
     let (cx, cy) = (x + cw, y + ch);
     let mut i = 0;
-    let (start, end) = if start_radians < end_radians {
-        (start_radians, end_radians)
-    } else {
-        (end_radians, start_radians)
-    };
-    let max_seg_size = <Scalar as Radians>::_360() / resolution as Scalar;
 
-    let delta = end - start;
+    let twopi = <Scalar as Radians>::_360();
+    let max_seg_size = twopi / resolution as Scalar;
+
+    // Take true modulus by 2pi.
+    let delta = (((end_radians - start_radians) % twopi) + twopi) % twopi;
 
     // Taking ceiling here implies that the resolution parameter provides a
     // lower bound on the drawn resolution.
@@ -388,7 +386,7 @@ pub fn with_arc_tri_list<F>(
     stream_quad_tri_list(m, || {
         if i > n_quads { return None; }
 
-        let angle = start + (i as Scalar * seg_size);
+        let angle = start_radians + (i as Scalar * seg_size);
 
         let cos = angle.cos();
         let sin = angle.sin();


### PR DESCRIPTION
This might actually have already been present anyway as it is related to logic I didn't change the first time.  Previously end was forced to be greater than start, but this is very wrong if, for instance, start is larger than end because we want a circle arc that includes the angle 0.  Current code, when asked to draw two circle arcs, from (multiply all angles by 2pi): 0.1 to 0.9 (green), 0.9 to 0.1 (red), draws:
![screen shot 2016-10-09 at 02 18 31](https://cloud.githubusercontent.com/assets/1912879/19219449/5a7b5974-8dc8-11e6-895e-3183bfdf1db1.png)
With this bug fix, it correctly draws an arc that spans 0 for the red arc:
![screen shot 2016-10-09 at 02 17 03](https://cloud.githubusercontent.com/assets/1912879/19219453/6f2ccbe6-8dc8-11e6-9cd3-fd0555635472.png)
