### PR TITLE
Allow sub-pixel precision in source rectangle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-graphics"
-version = "0.18.1"
+version = "0.19.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/image.rs
+++ b/src/image.rs
@@ -148,7 +148,7 @@ impl Image {
         let color = self.color.unwrap_or([1.0; 4]);
         let source_rectangle = self.source_rectangle.unwrap_or({
             let (w, h) = texture.get_size();
-            [0, 0, w as i32, h as i32]
+            [0.0, 0.0, w as Scalar, h as Scalar]
         });
         let rectangle = self.rectangle.unwrap_or([
             0.0,
@@ -200,6 +200,6 @@ mod test {
         let _img = Image::new()
             .color([1.0; 4])
             .rect([0.0, 0.0, 100.0, 100.0])
-            .src_rect([0, 0, 32, 32]);
+            .src_rect([0.0, 0.0, 32.0, 32.0]);
     }
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -320,11 +320,13 @@ mod test_overlap {
 /// Computes a relative source rectangle using
 /// the source rectangle as a tile.
 #[inline(always)]
-pub fn relative_source_rectangle(
-    rect: SourceRectangle,
-    x: i32,
-    y: i32
-) -> SourceRectangle {
+pub fn relative_source_rectangle<T>(
+    rect: SourceRectangle<T>,
+    x: T,
+    y: T
+) -> SourceRectangle<T>
+    where T: Float
+{
     let (rx, ry, rw, rh) = (rect[0], rect[1], rect[2], rect[3]);
     let (x, y) = (rx + x * rw, ry + y * rh);
     [x, y, rw, rh]

--- a/src/source_rectangled.rs
+++ b/src/source_rectangled.rs
@@ -1,15 +1,15 @@
-use math::relative_source_rectangle;
+use math::{relative_source_rectangle, Scalar};
 use types::SourceRectangle;
 
 /// Should be implemented by contexts that
 /// have source rectangle information.
 pub trait SourceRectangled {
     /// Adds a source rectangle.
-    fn src_rect(self, x: i32, y: i32, w: i32, h: i32) -> Self;
+    fn src_rect(self, x: Scalar, y: Scalar, w: Scalar, h: Scalar) -> Self;
 
     /// Moves to a relative source rectangle using
     /// the current source rectangle as tile.
-    fn src_rel(self, x: i32, y: i32) -> Self;
+    fn src_rel(self, x: Scalar, y: Scalar) -> Self;
 
     /// Flips the source rectangle horizontally.
     fn src_flip_h(self) -> Self;
@@ -23,12 +23,12 @@ pub trait SourceRectangled {
 
 impl SourceRectangled for SourceRectangle {
     #[inline(always)]
-    fn src_rect(self, x: i32, y: i32, w: i32, h: i32) -> Self {
+    fn src_rect(self, x: Scalar, y: Scalar, w: Scalar, h: Scalar) -> Self {
         [x, y, w, h]
     }
 
     #[inline(always)]
-    fn src_rel(self, x: i32, y: i32) -> Self {
+    fn src_rel(self, x: Scalar, y: Scalar) -> Self {
         relative_source_rectangle(self, x, y)
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,7 @@ pub type ColorComponent = f32;
 pub type Line<T=Scalar> = [T; 4];
 
 /// [x, y, w, h]
-pub type SourceRectangle = [i32; 4];
+pub type SourceRectangle<T=Scalar> = [T; 4];
 
 /// [p0, p1, ...]
 pub type Polygon<'a, T=Scalar> = &'a [Vec2d<T>];


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/graphics/issues/1067

- Bumped to 0.19.0
- Made `math::relative_source_rectangle` generic