### PR TITLE
Made `BACK_END_MAX_VERTEX_COUNT` a multiple of 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston2d-graphics"
-version = "0.21.0"
+version = "0.21.1"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,10 @@ pub use draw_state::DrawState;
 /// Any triangulation method called on the back-end
 /// never exceeds this number of vertices.
 /// This can be used to initialize buffers that fit the chunk size.
-pub const BACK_END_MAX_VERTEX_COUNT: usize = 1024;
+///
+/// Must be a multiple of 3 because you need 3 vertices per triangle
+/// in a triangle list.
+pub const BACK_END_MAX_VERTEX_COUNT: usize = 1023;
 
 mod graphics;
 mod source_rectangled;


### PR DESCRIPTION
- Bumped to 0.21.1

This fixes a bug where deform grid is not rendered properly, because
the buffer chunks cut the triangle in half.