### PR TITLE
Text rendering uses TextureSettings

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -2,6 +2,7 @@
 
 use types::{FontSize, Scalar};
 use ImageSize;
+use texture::TextureSettings;
 
 /// Holds rendered character data.
 #[derive(Clone)]
@@ -44,13 +45,14 @@ pub trait CharacterCache {
     /// Get reference to character.
     fn character<'a>(&'a mut self,
                      font_size: FontSize,
-                     ch: char)
+                     ch: char,
+                     settings: &TextureSettings)
                      -> Character<'a, <Self as CharacterCache>::Texture>;
 
     /// Return the width for some given text.
     fn width(&mut self, size: FontSize, text: &str) -> ::math::Scalar {
         text.chars().fold(0.0, |a, ch| {
-            let character = self.character(size, ch);
+            let character = self.character(size, ch, &TextureSettings::new());
             a + character.width()
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate read_color;
 extern crate interpolation;
 extern crate viewport;
 
-pub use texture::ImageSize;
+pub use texture::{ImageSize, TextureSettings};
 pub use viewport::Viewport;
 
 pub use graphics::Graphics;
@@ -172,5 +172,5 @@ pub fn text<C, G>(
         C: character::CharacterCache,
         G: Graphics<Texture = <C as character::CharacterCache>::Texture>
 {
-    Text::new_color(color, font_size).draw(text, cache, &Default::default(), transform, g)
+    Text::new_color(color, font_size).draw(text, cache, &Default::default(), transform, &TextureSettings::new(), g)
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -4,6 +4,7 @@ use types::{Color, FontSize};
 use {color, Image, Graphics, Transformed, DrawState};
 use character::CharacterCache;
 use math::Matrix2d;
+use texture::TextureSettings;
 
 /// Renders text
 #[derive(Copy, Clone)]
@@ -47,6 +48,7 @@ impl Text {
                       cache: &mut C,
                       draw_state: &DrawState,
                       transform: Matrix2d,
+                      settings: &TextureSettings, 
                       g: &mut G)
         where C: CharacterCache,
               G: Graphics<Texture = <C as CharacterCache>::Texture>
@@ -55,7 +57,7 @@ impl Text {
         let mut x = 0.0;
         let mut y = 0.0;
         for ch in text.chars() {
-            let character = cache.character(self.font_size, ch);
+            let character = cache.character(self.font_size, ch, settings);
             let mut ch_x = x + character.left();
             let mut ch_y = y - character.top();
             if self.round {


### PR DESCRIPTION
There are situations where it would be nice to control how text is filtered and rendered, and passing a `&TextureSettings` to `CharacterCache.character` would allow that. If the rendering of the text is unimportant, like in `CharacterCache.width`, the default can be used.

This is naturally going to break the backends, so I'll work on PRs for them as well.

EDIT: I now think it would be a better idea for `CharacterCache` to store a `TextureSettings`, so let me commit that first before considering the PR.