### PR TITLE
Update to rusttype 0.5.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ read_color = "1.0.0"
 vecmath = "0.3.0"
 
 [dependencies.rusttype]
-version = "0.4.0"
+version = "0.5.0"
 optional = true
 
 [dependencies.fnv]


### PR DESCRIPTION
The newest release of the rusttype crate makes some changes to the way errors are reported.