### PR TITLE
Texture atlas for glyphs using new heuristic texture packer

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -8,8 +8,12 @@ use ImageSize;
 pub struct Character<'a, T: 'a + ImageSize> {
     /// The offset of character.
     pub offset: [Scalar; 2],
-    /// The size of character, including space.
-    pub size: [Scalar; 2],
+    /// The advance size of character, including space.
+    pub advance_size: [Scalar; 2],
+    /// The offset of character within texture atlas.
+    pub atlas_offset: [Scalar; 2],
+    /// The size of character within texture atlas.
+    pub atlas_size: [Scalar; 2],
     /// The texture of the character.
     pub texture: &'a T,
 }
@@ -26,13 +30,13 @@ impl<'a, T: ImageSize> Character<'a, T> {
     }
 
     /// Gets width of character, including space to the next one.
-    pub fn width(&self) -> Scalar {
-        self.size[0]
+    pub fn advance_width(&self) -> Scalar {
+        self.advance_size[0]
     }
 
     /// Sets height of character, including space to the next one.
-    pub fn height(&self) -> Scalar {
-        self.size[1]
+    pub fn advance_height(&self) -> Scalar {
+        self.advance_size[1]
     }
 }
 
@@ -54,7 +58,7 @@ pub trait CharacterCache {
         let mut width = 0.0;
         for ch in text.chars() {
             let character = self.character(size, ch)?;
-            width += character.width();
+            width += character.advance_width();
         }
         Ok(width)
     }

--- a/src/glyph_cache/rusttype.rs
+++ b/src/glyph_cache/rusttype.rs
@@ -25,8 +25,8 @@ struct Data {
     texture: usize,
 }
 
-pub const ATLAS_WIDTH: u32 = 256;
-pub const ATLAS_HEIGHT: u32 = 256;
+/// The minimum atlas size.
+pub const ATLAS_SIZE: [u32; 2] = [256; 2];
 
 /// A struct used for caching rendered font.
 pub struct GlyphCache<'a, F, T> {
@@ -196,8 +196,8 @@ impl<'b, F, T: ImageSize> CharacterCache for GlyphCache<'b, F, T>
                     None => {
                         // Create a new texture atlas.
                         let mut image_buffer = Vec::<u8>::new();
-                        let w = size[0].max(ATLAS_WIDTH) as u32;
-                        let h = size[1].max(ATLAS_HEIGHT) as u32;
+                        let w = size[0].max(ATLAS_SIZE[0]) as u32;
+                        let h = size[1].max(ATLAS_SIZE[1]) as u32;
                         image_buffer.resize((w * h) as usize, 0);
                         glyph.draw(|x, y, v| {
                             let pos = ((x + 1) + (y + 1) * w) as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ pub mod math;
 pub mod deform;
 pub mod grid;
 pub mod glyph_cache;
+pub mod texture_packer;
 
 pub mod radians {
     //! Reexport radians helper trait from vecmath

--- a/src/text.rs
+++ b/src/text.rs
@@ -54,20 +54,25 @@ impl Text {
     {
         let mut image = Image::new_color(self.color);
         let mut x = 0.0;
+        let mut y = 0.0;
         for ch in text.chars() {
             let character = cache.character(self.font_size, ch)?;
             let mut ch_x = x + character.left();
-            let mut ch_y = -character.top();
+            let mut ch_y = y - character.top();
             if self.round {
                 ch_x = ch_x.round();
                 ch_y = ch_y.round();
             }
-            image = image.src_rect([0.0, 0.0, character.width(), character.height()]);
+            image = image.src_rect([
+                character.atlas_offset[0], character.atlas_offset[1],
+                character.atlas_size[0], character.atlas_size[1]
+            ]);
             image.draw(character.texture,
                        draw_state,
                        transform.trans(ch_x, ch_y),
                        g);
-            x += character.width();
+            x += character.advance_width();
+            y += character.advance_height();
         }
         Ok(())
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -53,6 +53,7 @@ impl Text {
               G: Graphics<Texture = <C as CharacterCache>::Texture>
     {
         let mut image = Image::new_color(self.color);
+
         let mut x = 0.0;
         let mut y = 0.0;
         for ch in text.chars() {
@@ -74,6 +75,7 @@ impl Text {
             x += character.advance_width();
             y += character.advance_height();
         }
+
         Ok(())
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -52,23 +52,22 @@ impl Text {
         where C: CharacterCache,
               G: Graphics<Texture = <C as CharacterCache>::Texture>
     {
-        let image = Image::new_color(self.color);
+        let mut image = Image::new_color(self.color);
         let mut x = 0.0;
-        let mut y = 0.0;
         for ch in text.chars() {
             let character = cache.character(self.font_size, ch)?;
             let mut ch_x = x + character.left();
-            let mut ch_y = y - character.top();
+            let mut ch_y = -character.top();
             if self.round {
                 ch_x = ch_x.round();
                 ch_y = ch_y.round();
             }
+            image = image.src_rect([0.0, 0.0, character.width(), character.height()]);
             image.draw(character.texture,
                        draw_state,
                        transform.trans(ch_x, ch_y),
                        g);
             x += character.width();
-            y += character.height();
         }
         Ok(())
     }

--- a/src/texture_packer.rs
+++ b/src/texture_packer.rs
@@ -101,7 +101,7 @@ impl<T: ImageSize> TexturePacker<T> {
         (texture, offset)
     }
 
-    /// Returns the index of atlas offset with room for a new glyph.
+    /// Returns the index of atlas offset in skyline with room for a new tile.
     ///
     /// Returns `None` if no room was found in the current texture atlas.
     pub fn find_space(

--- a/src/texture_packer.rs
+++ b/src/texture_packer.rs
@@ -2,7 +2,9 @@
 
 use ImageSize;
 
-/// A heuristic texture packer using a sorted list of atlas offsets.
+/// A texture packer using a skyline heuristic.
+///
+/// For offline texture packing, see [texture_packer](https://github.com/pistondevelopers/texture_packer).
 ///
 /// Designed for adding textures one by one to current texture atlas.
 /// Packs tiles without backtracking or knowledge about future tiles.
@@ -10,14 +12,21 @@ use ImageSize;
 /// - Perfect at packing tiles of same size
 /// - Good at packing tiles of some unit size
 /// - Decent at packing tiles of similar sizes
+/// - Can be used with pre-sorted tile sizes for better packing
 ///
 /// Can also be used as storage for textures.
 ///
-/// Only a single list of atlas offsets are kept track of,
+/// ### Design
+///
+/// A skyline is a list of non-hole atlas offsets,
+/// used to efficiently determine the a good place to put the next tile.
+///
+/// In this texture packer,
+/// only a single skyline is kept track of,
 /// since new texture atlases are created by need.
 ///
-/// This texture packer has runtime complexity `O(N^2)`,
-/// where `N` is the number of atlas offsets.
+/// This texture packer has runtime complexity `O(N^2)` for inserting a new tile,
+/// where `N` is the number of points in the skyline.
 /// Since `N` is usually a low number, the packing is pretty fast.
 ///
 /// The algorithm was designed by Sven Nilsen (2019) for Piston-Graphics.
@@ -31,7 +40,7 @@ pub struct TexturePacker<T> {
     /// When a new tile is added with same offset,
     /// it updates the atlas offsets that it overlaps.
     /// This means that "holes" get filled in over time.
-    pub atlas_offsets: Vec<[u32; 2]>,
+    pub skyline: Vec<[u32; 2]>,
 }
 
 impl<T: ImageSize> TexturePacker<T> {
@@ -40,7 +49,7 @@ impl<T: ImageSize> TexturePacker<T> {
         TexturePacker {
             textures: vec![],
             atlas: 0,
-            atlas_offsets: vec![],
+            skyline: vec![],
         }
     }
 
@@ -52,7 +61,7 @@ impl<T: ImageSize> TexturePacker<T> {
         if self.textures.len() > 0 {
             self.atlas += 1;
         }
-        self.atlas_offsets = vec![
+        self.skyline = vec![
             [0, size[1]],
             [size[0], 0],
         ];
@@ -62,27 +71,31 @@ impl<T: ImageSize> TexturePacker<T> {
 
     /// Update current texture atlas.
     ///
-    /// Returns the
+    /// - ind: index of atlas offset in the skyline
+    /// - size: size of new tile
+    ///
+    /// Returns the index of the current texture atlas and
+    /// the atlas offset of the new tile.
     pub fn update(&mut self, ind: usize, size: [u32; 2]) -> (usize, [u32; 2]) {
         let texture = self.atlas;
-        let offset = self.atlas_offsets[ind];
+        let offset = self.skyline[ind];
 
         // Increase y-value of atlas offsets that are matched.
         let mut w = 0;
-        for i in ind..self.atlas_offsets.len() {
-            if self.atlas_offsets[i][1] <= offset[1] {
-                self.atlas_offsets[i][1] = offset[1] + size[1];
+        for i in ind..self.skyline.len() {
+            if self.skyline[i][1] <= offset[1] {
+                self.skyline[i][1] = offset[1] + size[1];
             }
-            w = self.atlas_offsets[i][0] - offset[0];
+            w = self.skyline[i][0] - offset[0];
             if w >= size[1] {
                 break;
             }
         }
         if w == 0 {
-            // There are no end-point atlas offset.
+            // There is no end-point atlas offset.
             // Add new atlas offset point.
-            self.atlas_offsets.push([offset[0] + size[0], offset[1]]);
-            self.atlas_offsets.sort();
+            self.skyline.push([offset[0] + size[0], offset[1]]);
+            self.skyline.sort();
         }
 
         (texture, offset)
@@ -99,13 +112,13 @@ impl<T: ImageSize> TexturePacker<T> {
 
         let texture = &self.textures[self.atlas];
         let mut min: Option<(usize, u32)> = None;
-        'next: for i in 0..self.atlas_offsets.len() {
-            let a = self.atlas_offsets[i];
+        'next: for i in 0..self.skyline.len() {
+            let a = self.skyline[i];
             let mut nxt = [texture.get_width(), texture.get_height()];
             // Ignore next atlas offsets that have smaller y-value,
             // because they do not interfer.
-            for j in i+1..self.atlas_offsets.len() {
-                let b = self.atlas_offsets[j];
+            for j in i+1..self.skyline.len() {
+                let b = self.skyline[j];
                 nxt[0] = b[0];
                 if b[1] > a[1] {break};
             }
@@ -113,7 +126,7 @@ impl<T: ImageSize> TexturePacker<T> {
                 // There is room for the glyph.
                 if min.is_none() ||
                     min.unwrap().1 > nxt[0] - a[0] ||
-                    self.atlas_offsets[min.unwrap().0][1] > a[1]
+                    self.skyline[min.unwrap().0][1] > a[1]
                 {
                     // Pick the space with smallest y-value.
                     min = Some((i, nxt[0] - a[0]));

--- a/src/texture_packer.rs
+++ b/src/texture_packer.rs
@@ -1,0 +1,123 @@
+//! Texture packing.
+
+use ImageSize;
+
+/// A heuristic texture packer using a sorted list of atlas offsets.
+///
+/// Designed for adding textures one by one to current texture atlas.
+/// Packs tiles without backtracking or knowledge about future tiles.
+///
+/// - Perfect at packing tiles of same size
+/// - Good at packing tiles of some unit size
+/// - Decent at packing tiles of similar sizes
+///
+/// Can also be used as storage for textures.
+///
+/// Only a single list of atlas offsets are kept track of,
+/// since new texture atlases are created by need.
+///
+/// This texture packer has runtime complexity `O(N^2)`,
+/// where `N` is the number of atlas offsets.
+/// Since `N` is usually a low number, the packing is pretty fast.
+///
+/// The algorithm was designed by Sven Nilsen (2019) for Piston-Graphics.
+pub struct TexturePacker<T> {
+    /// Stores current texture atlas and previously created ones.
+    pub textures: Vec<T>,
+    /// The index to the current texture atlas.
+    pub atlas: usize,
+    /// Texture atlas offsets from left to right.
+    ///
+    /// These atlas offsets are from top to bottom.
+    pub atlas_offsets: Vec<[u32; 2]>,
+}
+
+impl<T: ImageSize> TexturePacker<T> {
+    /// Returns a new `TexturePacker`.
+    pub fn new() -> TexturePacker<T> {
+        TexturePacker {
+            textures: vec![],
+            atlas: 0,
+            atlas_offsets: vec![],
+        }
+    }
+
+    /// Create a new texture atlas with an initial tile.
+    ///
+    /// The new texture atlas is made the current one.
+    pub fn create(&mut self, size: [u32; 2], texture: T) -> usize {
+        let id = self.textures.len();
+        if self.textures.len() > 0 {
+            self.atlas += 1;
+        }
+        self.atlas_offsets = vec![
+            [0, size[1]],
+            [size[0], 0],
+        ];
+        self.textures.push(texture);
+        id
+    }
+
+    /// Update current texture atlas.
+    ///
+    /// Returns the
+    pub fn update(&mut self, ind: usize, size: [u32; 2]) -> (usize, [u32; 2]) {
+        let texture = self.atlas;
+        let offset = self.atlas_offsets[ind];
+
+        // Increase y-value of atlas offsets that are matched.
+        let mut w = 0;
+        for i in ind..self.atlas_offsets.len() {
+            if self.atlas_offsets[i][1] <= offset[1] {
+                self.atlas_offsets[i][1] = offset[1] + size[1];
+            }
+            w = self.atlas_offsets[i][0] - offset[0];
+            if w >= size[1] {
+                break;
+            }
+        }
+        if w == 0 {
+            // There are no end-point atlas offset.
+            // Add new atlas offset point.
+            self.atlas_offsets.push([offset[0] + size[0], offset[1]]);
+            self.atlas_offsets.sort();
+        }
+
+        (texture, offset)
+    }
+
+    /// Returns the index of atlas offset with room for a new glyph.
+    ///
+    /// Returns `None` if no room was found in the current texture atlas.
+    pub fn find_space(
+        &self,
+        size: [u32; 2]
+    ) -> Option<usize> {
+        if self.textures.len() == 0 {return None};
+
+        let texture = &self.textures[self.atlas];
+        let mut min: Option<(usize, u32)> = None;
+        'next: for i in 0..self.atlas_offsets.len() {
+            let a = self.atlas_offsets[i];
+            let mut nxt = [texture.get_width(), texture.get_height()];
+            // Ignore next atlas offsets that have smaller y-value,
+            // because they do not interfer.
+            for j in i+1..self.atlas_offsets.len() {
+                let b = self.atlas_offsets[j];
+                nxt[0] = b[0];
+                if b[1] > a[1] {break};
+            }
+            if nxt[0] - a[0] >= size[0] && nxt[1] - a[1] >= size[1] {
+                // There is room for the glyph.
+                if min.is_none() ||
+                    min.unwrap().1 > nxt[0] - a[0] ||
+                    self.atlas_offsets[min.unwrap().0][1] > a[1]
+                {
+                    // Pick the space with smallest y-value.
+                    min = Some((i, nxt[0] - a[0]));
+                }
+            }
+        }
+        min.map(|n| n.0)
+    }
+}

--- a/src/texture_packer.rs
+++ b/src/texture_packer.rs
@@ -28,7 +28,9 @@ pub struct TexturePacker<T> {
     pub atlas: usize,
     /// Texture atlas offsets from left to right.
     ///
-    /// These atlas offsets are from top to bottom.
+    /// When a new tile is added with same offset,
+    /// it updates the atlas offsets that it overlaps.
+    /// This means that "holes" get filled in over time.
     pub atlas_offsets: Vec<[u32; 2]>,
 }
 

--- a/src/texture_packer.rs
+++ b/src/texture_packer.rs
@@ -19,7 +19,7 @@ use ImageSize;
 /// ### Design
 ///
 /// A skyline is a list of non-hole atlas offsets,
-/// used to efficiently determine the a good place to put the next tile.
+/// used to efficiently determine a good place to put the next tile.
 ///
 /// In this texture packer,
 /// only a single skyline is kept track of,


### PR DESCRIPTION
This PR adds a new heuristic texture packer which works pretty decently without backtracking or future knowledge of tiles (skyline). The algorithm is `O(N^2)` for packing a new tile where `N` is the number of points in the skyline. Since this is usually a low number, the packing is pretty fast. It means it can e.g. pack glyphs into textures with hard performance guarantees that there will be no re-packing later.

- Updated RustType glyph cache to use the new heuristic texture packer
- Updated `Character` with fields for sub-rectangles