### PR TITLE
Add "Blend::Lighter" mode

### DIFF
--- a/src/draw_state.rs
+++ b/src/draw_state.rs
@@ -91,6 +91,13 @@ pub enum Blend {
     /// new_dest_alpha = src_alpha + dest_alpha
     /// ```
     Add,
+    /// Screen blending.
+    ///
+    /// ```not_rust
+    /// new_dest_color = src_color * src_alpha + dest_color
+    /// new_dest_alpha = src_alpha + dest_alpha
+    /// ```
+    Screen,
     /// Multiply color components.
     ///
     /// ```not_rust

--- a/src/draw_state.rs
+++ b/src/draw_state.rs
@@ -91,13 +91,13 @@ pub enum Blend {
     /// new_dest_alpha = src_alpha + dest_alpha
     /// ```
     Add,
-    /// Screen blending.
+    /// Additive blending with alpha channel.
     ///
     /// ```not_rust
     /// new_dest_color = src_color * src_alpha + dest_color
-    /// new_dest_alpha = src_alpha + dest_alpha
+    /// new_dest_alpha = dest_alpha
     /// ```
-    Screen,
+    Lighter,
     /// Multiply color components.
     ///
     /// ```not_rust


### PR DESCRIPTION
Added a blend mode called `Blend::Lighter`, which is an additive blend mode with alpha channel capability.

The equation is:
```
new_dest_color = src_color * src_alpha + dest_color
new_dest_alpha = dest_alpha
```

See [here](https://github.com/PistonDevelopers/piston/issues/1327) for more details.

back-end support:
☑ gfx_graphics (PistonDevelopers/gfx_graphics/pull/357)
☐ opengl_graphics
☐ glium_graphics
