### PR TITLE
Update rusttype to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ read_color = "1.0.0"
 vecmath = "1.0.0"
 
 [dependencies.rusttype]
-version = "0.8.0"
+version = "0.9.0"
 optional = true
 
 [dependencies.fnv]


### PR DESCRIPTION
Updating rusttype to 0.9 removes the dependency on `stb_truetype`, which is [deprecated](https://rustsec.org/advisories/RUSTSEC-2020-0020).