### PR TITLE
Fix type mismatch for conrod_piston::draw::Context fields 

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -10,9 +10,9 @@ pub struct Context {
     /// Viewport information.
     pub viewport: Option<Viewport>,
     /// View transformation.
-    pub view: Matrix2d,
+    pub view: [[f64; 3]; 2],
     /// Current transformation.
-    pub transform: Matrix2d,
+    pub transform: [[f64; 3]; 2],
     /// Current draw state settings.
     pub draw_state: DrawState,
 }


### PR DESCRIPTION
This pull request fixes a type mismatch for fields "view" and "transform" in conrod_piston::draw::Context fields.

