### PR TITLE
add 'invalid character" field to character struct

### DIFF
--- a/src/character.rs
+++ b/src/character.rs
@@ -19,6 +19,8 @@ pub struct Character<'a, T: ImageSize> {
     pub atlas_size: [Scalar; 2],
     /// The texture of the character.
     pub texture: &'a T,
+    /// if this is an "invalid character" character
+    pub is_invalid: bool
 }
 
 impl<'a, T: ImageSize> Character<'a, T> {

--- a/src/glyph_cache/rusttype.rs
+++ b/src/glyph_cache/rusttype.rs
@@ -20,6 +20,7 @@ struct Data {
     atlas_offset: [Scalar; 2],
     atlas_size: [Scalar; 2],
     texture: usize,
+    is_invalid: bool
 }
 
 struct EmptyOutlineBuilder;
@@ -128,6 +129,7 @@ where
                  atlas_offset,
                  atlas_size,
                  texture,
+                 is_invalid,
              }| {
                 Character {
                     offset,
@@ -135,6 +137,7 @@ where
                     atlas_offset,
                     atlas_size,
                     texture: &self.texture_packer.textures[texture],
+                    is_invalid,
                 }
             },
         )
@@ -164,6 +167,7 @@ where
                     atlas_offset,
                     atlas_size,
                     texture,
+                    is_invalid,
                 } = v.into_mut();
                 Ok(Character {
                     offset,
@@ -171,6 +175,7 @@ where
                     atlas_offset,
                     atlas_size,
                     texture: &self.texture_packer.textures[texture],
+                    is_invalid,
                 })
             }
             Entry::Vacant(v) => {
@@ -200,12 +205,15 @@ where
                     (pixel_bounding_box.height() + 2) as u32,
                 ];
 
+                let is_invalid = glyph.id() == rt::GlyphId(0);
+
                 let &mut Data {
                     offset,
                     advance_size,
                     atlas_offset,
                     atlas_size,
                     texture,
+                    is_invalid,
                 } = match self.texture_packer.find_space(size) {
                     None => {
                         // Create a new texture atlas.
@@ -239,6 +247,7 @@ where
                             atlas_offset: [0.0; 2],
                             atlas_size: [size[0] as Scalar, size[1] as Scalar],
                             texture,
+                            is_invalid,
                         })
                     }
                     Some(ind) => {
@@ -268,6 +277,7 @@ where
                             atlas_offset: [offset[0] as Scalar, offset[1] as Scalar],
                             atlas_size: [size[0] as Scalar, size[1] as Scalar],
                             texture,
+                            is_invalid
                         })
                     }
                 };
@@ -277,6 +287,7 @@ where
                     atlas_offset,
                     atlas_size,
                     texture: &self.texture_packer.textures[texture],
+                    is_invalid
                 })
             }
         }


### PR DESCRIPTION
This will help with adding fallback font support downstream.

NOTE! This may be breaking if someone uses custom implementation of Character (since it adds an extra field).
I'm not sure how likely this is to actually occur though.

I'm creating a PR regardless because I believe this would be extremely useful for games, especially multi-lingual games (like rhythm games, which is what I'm working on) where having multiple languages in the same text block is a common occurrence.

I did a quick cargo-check with the 3 main backends and they all build fine, so I assume there are no compatibility issues there.|

This was tested with Roboto trying to display Chinese characters (也馳驰), and using Kosugi Maru Regular to display the same characters. Displayed (valid) characters show as valid, and Errored (invalid) characters show as invalid.