### PR TITLE
Fix: Color components go up to 1.0 (not 255.0)

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -5,39 +5,41 @@ use crate::types::{Color, ColorComponent};
 /// Black color.
 pub const BLACK: Color = [0.0, 0.0, 0.0, 1.0];
 /// Blue color.
-pub const BLUE: Color = [0.0, 0.0, 255.0, 1.0];
+pub const BLUE: Color = [0.0, 0.0, 1.0, 1.0];
 /// Cyan color.
-pub const CYAN: Color = [0.0, 255.0, 255.0, 1.0];
+pub const CYAN: Color = [0.0, 1.0, 1.0, 1.0];
 /// Gray color.
-pub const GRAY: Color = [128.0, 128.0, 128.0, 1.0];
+pub const GRAY: Color = [0.5, 0.5, 0.5, 1.0];
 /// Green color.
-pub const GREEN: Color = [0.0, 128.0, 0.0, 1.0];
+pub const GREEN: Color = [0.0, 0.5, 0.0, 1.0];
 /// Lime color.
-pub const LIME: Color = [0.0, 255.0, 0.0, 1.0];
+pub const LIME: Color = [0.0, 1.0, 0.0, 1.0];
 /// Magenta color.
-pub const MAGENTA: Color = [255.0, 0.0, 255.0, 1.0];
+pub const MAGENTA: Color = [1.0, 0.0, 1.0, 1.0];
 /// Maroon color.
-pub const MAROON: Color = [128.0, 0.0, 0.0, 1.0];
+pub const MAROON: Color = [0.5, 0.0, 0.0, 1.0];
 /// Navy color.
-pub const NAVY: Color = [0.0, 0.0, 128.0, 1.0];
+pub const NAVY: Color = [0.0, 0.0, 0.5, 1.0];
 /// Olive color.
-pub const OLIVE: Color = [128.0, 128.0, 0.0, 1.0];
+pub const OLIVE: Color = [0.5, 0.5, 0.0, 1.0];
 /// Purple color.
-pub const PURPLE: Color = [128.0, 0.0, 128.0, 1.0];
+pub const PURPLE: Color = [0.5, 0.0, 0.5, 1.0];
 /// Red color.
-pub const RED: Color = [255.0, 0.0, 0.0, 1.0];
+pub const RED: Color = [1.0, 0.0, 0.0, 1.0];
 /// Silver color.
-pub const SILVER: Color = [192.0, 192.0, 192.0, 1.0];
+pub const SILVER: Color = [0.75, 0.75, 0.75, 1.0];
 /// Teal color.
-pub const TEAL: Color = [0.0, 128.0, 128.0, 1.0];
+pub const TEAL: Color = [0.0, 0.5, 0.5, 1.0];
 /// White color.
-pub const WHITE: Color = [255.0, 255.0, 255.0, 1.0];
+pub const WHITE: Color = [1.0, 1.0, 1.0, 1.0];
 /// Yellow color.
-pub const YELLOW: Color = [255.0, 255.0, 0.0, 1.0];
+pub const YELLOW: Color = [1.0, 1.0, 0.0, 1.0];
 /// Transparent color.
 pub const TRANSPARENT: Color = [0.0; 4];
 
 /// Returns a grey color
+/// # Arguments
+/// * `f` - The brightness of the color. 0.0 is black, 1.0 is white
 pub fn grey(f: ColorComponent) -> Color {
     [f, f, f, 1.0]
 }

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -40,7 +40,22 @@ pub fn rectangle_by_corners(x0: Scalar, y0: Scalar, x1: Scalar, y1: Scalar) -> t
     [xmin, ymin, w, h]
 }
 
-/// Use x, y, half-width, half-height
+/// Create a centered rectangle.
+///
+/// `rect` is interpreted as `[x, y, half_width, half_height]`
+///
+/// Note that passing an existing `types::Rectangle` in here will not produce a rectangle of the
+/// same
+/// dimensions
+///
+/// # Example
+/// ```
+/// use graphics::rectangle::centered;
+///
+/// // We create a rectangle centered on [0.0, 0.0] with width 2.0 and height 6.0
+/// let centered_rect = centered([0.0, 0.0, 1.0, 3.0]);
+/// assert_eq!(centered_rect, [-1.0, -3.0, 2.0, 6.0]);
+/// ```
 pub fn centered(rect: types::Rectangle) -> types::Rectangle {
     [
         rect[0] - rect[2],


### PR DESCRIPTION
Fixed the preset colors, and documented the "grey" function.

With the scale going up to 255 some colors seem to work, but others (like OLIVE and GRAY) are the wrong color